### PR TITLE
feat: 기록 생성 API 구현 완료 (#7)

### DIFF
--- a/src/main/java/umc/fitty/config/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/umc/fitty/config/security/jwt/JwtAuthFilter.java
@@ -5,6 +5,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import umc.fitty.config.security.CustomUserDetailService;
@@ -32,9 +35,28 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = authHeader.substring(7);
 
-        if (!jwtUtil.validateToken(token)) {
-            chain.doFilter(request, response);
-            return;
+//        if (!jwtUtil.validateToken(token)) {
+//            chain.doFilter(request, response);
+//            return;
+//        }
+
+        if (jwtUtil.validateToken(token)) {
+            // 1. 토큰이 유효하면, 토큰에서 사용자 ID를 추출합니다.
+            Long userId = jwtUtil.extractUserId(token);
+
+            // 2. 사용자 ID를 기반으로 UserDetails 객체를 가져옵니다.
+            UserDetails userDetails = customUserDetailService.loadUserByUsername(String.valueOf(userId));
+
+            // 3. UserDetails를 기반으로 Authentication 객체를 생성합니다.
+            //    이 객체는 Spring Security가 현재 사용자를 인식하는 데 사용됩니다.
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            // 4. SecurityContextHolder에 생성된 Authentication 객체를 설정합니다.
+            //    이것이 바로 "현재 사용자를 인증 처리"하는 과정입니다.
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
+        chain.doFilter(request, response);
     }
 }

--- a/src/main/java/umc/fitty/service/RunRecordService/RecordCommandServiceImpl.java
+++ b/src/main/java/umc/fitty/service/RunRecordService/RecordCommandServiceImpl.java
@@ -1,7 +1,10 @@
 package umc.fitty.service.RunRecordService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.fitty.apiPayload.code.ErrorCode;
 import umc.fitty.apiPayload.exception.CustomException;
 import umc.fitty.converter.RecordConverter;
@@ -19,6 +22,7 @@ import java.time.temporal.TemporalAdjusters;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RecordCommandServiceImpl implements RecordCommandService {
 
     private final RecordRepository recordRepository;
@@ -29,7 +33,10 @@ public class RecordCommandServiceImpl implements RecordCommandService {
     public RunRecord createRecord(RunRecordRequestDTO.CreateRecordDTO request) {
         RunRecord newRecord = RecordConverter.toRunRecord(request);
 
-        User user = userRepository.findById(1L).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+
+        User user = userRepository.findById(Long.parseLong(userId)).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         LocalDate today = LocalDate.now();
         LocalDate weekMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));


### PR DESCRIPTION
## 🔥 Related Issues
- close #7

## 💻 작업 내용
- [x] 기록 생성 API의 핵심 로직을 구현했습니다.
- [x] 임시 유저 ID(1L) 대신, 실제 로그인한 사용자 정보를 이용하도록 수정했습니다.
- [x] JWT 인증이 정상적으로 처리되지 않아 발생하던 403 권한 오류를 JwtAuthFilter 수정으로 해결했습니다.

## ✅ PR Point
기존에 임시로 사용하던 1L 유저 ID 대신 실제 로그인한 사용자의 ID를 가져와서 기록을 생성하도록 수정했습니다.

기록 생성을 시도하니 403에러 권한이 없다고합니다. 그래서 JwtAuthFilter 수정으로 해결했습니다.