### PR TITLE
feat: 기록 삭제 구현 완료

### DIFF
--- a/src/main/java/umc/fitty/apiPayload/code/ErrorCode.java
+++ b/src/main/java/umc/fitty/apiPayload/code/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 
     GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "목표 정보를 찾을 수 없습니다."),
 
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "기록 정보를 찾을 수 없습니다."),
+
     // User Error
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),
     EMAIL_ALREADY_USED(HttpStatus.BAD_REQUEST,"이미 존재하는 이메일입니다."),

--- a/src/main/java/umc/fitty/domain/Goal.java
+++ b/src/main/java/umc/fitty/domain/Goal.java
@@ -50,5 +50,11 @@ public class Goal extends BaseEntity {
         this.progressCount += 1;
     }
 
+    public void decreaseProgress(Double distance, Integer durationMin){
+        this.progressDistance -= distance;
+        this.progressTime -= durationMin;
+        this.progressCount -= 1;
+    }
+
 
 }

--- a/src/main/java/umc/fitty/service/RunRecordService/RecordCommandService.java
+++ b/src/main/java/umc/fitty/service/RunRecordService/RecordCommandService.java
@@ -6,4 +6,5 @@ import umc.fitty.web.dto.RunRecordDTO.RunRecordRequestDTO;
 public interface RecordCommandService {
 
     RunRecord createRecord(RunRecordRequestDTO.CreateRecordDTO request);
+    void deleteRecord(Long recordId);
 }

--- a/src/main/java/umc/fitty/service/RunRecordService/RecordCommandServiceImpl.java
+++ b/src/main/java/umc/fitty/service/RunRecordService/RecordCommandServiceImpl.java
@@ -49,4 +49,15 @@ public class RecordCommandServiceImpl implements RecordCommandService {
 
         return recordRepository.save(newRecord);
     }
+
+    @Override
+    public void deleteRecord(Long recordId) {
+        RunRecord record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
+
+        Goal goal = record.getGoal();
+        goal.decreaseProgress(record.getDistance(), record.getDurationMin());
+
+        recordRepository.delete(record);
+    }
 }

--- a/src/main/java/umc/fitty/web/controller/RunRecordRestController.java
+++ b/src/main/java/umc/fitty/web/controller/RunRecordRestController.java
@@ -1,10 +1,7 @@
 package umc.fitty.web.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.fitty.apiPayload.ApiResponse;
 import umc.fitty.converter.RecordConverter;
 import umc.fitty.domain.RunRecord;
@@ -24,5 +21,11 @@ public class RunRecordRestController {
         RunRecord newRecord = recordCommandService.createRecord(request);
 
         return ApiResponse.success("기록이 성공적으로 생성되었습니다.", RecordConverter.toCreateResultDTO(newRecord));
+    }
+
+    @DeleteMapping("/{recordId}")
+    public ApiResponse<String> deleteRecord(@PathVariable Long recordId) {
+        recordCommandService.deleteRecord(recordId);
+        return ApiResponse.success("기록이 성공적으로 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #9

## 💻 작업 내용
- [x] 기록 삭제 API 구현
- [x] 기록 삭제 시, 해당 기록으로 인해 증가했던 Goal의 진행률을 다시 차감하는 로직 적용

## ✅ PR Point
- RecordCommandServiceImpl의 deleteRecord 메서드를 확인해 주세요.
- D로 RunRecord를 찾아서 삭제하기 전에, 먼저 연결된 Goal 엔티티를 가져와 decreaseProgress 메서드를 호출하도록 구현했습니다. 이를 통해 운동 기록을 삭제하면 관련 주간 목표의 달성도(거리, 시간, 횟수)가 다시 줄어들어 데이터 일관성을 유지하도록 했습니다.

