### PR TITLE
feat: 이메일 추가

### DIFF
--- a/src/main/java/umc/fitty/domain/User.java
+++ b/src/main/java/umc/fitty/domain/User.java
@@ -5,23 +5,20 @@ import lombok.*;
 import umc.fitty.domain.common.BaseEntity;
 
 @Entity
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(indexes = {
-        @Index(name = "idx_provider_provider_id", columnList = "provider, providerId", unique = true)
+@Table(name = "user", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email"})
 })
+@Getter @Builder
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private AuthProvider provider;  // KAKAO
-
     @Column(nullable = false, length = 50)
-    private String providerId;      // 카카오의 user id(숫자지만 문자열 보관 권장)
+    private String kakaoId;
+
+    @Column(length = 100, unique = true)
+    private String email;
 
     @Column(nullable = false, length = 50)
     private String nickname;
@@ -29,8 +26,9 @@ public class User extends BaseEntity {
     @Column(length = 255)
     private String profileImageUrl;
 
-    public void updateProfile(String nickname, String profileImageUrl) {
-        if (nickname != null && !nickname.isBlank()) this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
+    public void updateFromKakao(String email, String nickname, String profileImageUrl) {
+        if (email != null) this.email = email;
+        if (nickname != null) this.nickname = nickname;
+        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/umc/fitty/repository/UserRepository.java
+++ b/src/main/java/umc/fitty/repository/UserRepository.java
@@ -1,11 +1,11 @@
 package umc.fitty.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import umc.fitty.domain.AuthProvider;
 import umc.fitty.domain.User;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(String kakaoId);
 }

--- a/src/main/java/umc/fitty/service/KakaoService.java
+++ b/src/main/java/umc/fitty/service/KakaoService.java
@@ -83,12 +83,17 @@ public class KakaoService {
         KakaoUserInfoResponseDto info = getUserInfo(kakaoAccessToken);
 
         String kakaoId   = String.valueOf(info.getId());
+        String email = (info.getKakaoAccount() != null) ? info.getKakaoAccount().getEmail() : null;
         String nickname  = (info.getKakaoAccount() != null && info.getKakaoAccount().getProfile() != null)
                 ? info.getKakaoAccount().getProfile().getNickName() : null;
         String profile   = (info.getKakaoAccount() != null && info.getKakaoAccount().getProfile() != null)
                 ? info.getKakaoAccount().getProfile().getProfileImageUrl() : null;
 
-        User user = userService.upsertFromKakao(kakaoId, nickname, profile);
+        if (email == null || email.isBlank()) {
+            throw new IllegalStateException("Kakao email is null/blank. Check 'account_email' scope & consent.");
+        }
+
+        User user = userService.upsertFromKakao(kakaoId, email, nickname, profile);
         String access = jwtUtil.createAccessToken(user.getId());
 
         return new JwtToken(access);

--- a/src/main/java/umc/fitty/service/UserService.java
+++ b/src/main/java/umc/fitty/service/UserService.java
@@ -12,17 +12,17 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public User upsertFromKakao(String kakaoId, String nickname, String profileImageUrl) {
-        return userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, kakaoId)
+    public User upsertFromKakao(String kakaoId, String email, String nickname, String profileImageUrl) {
+        return userRepository.findByEmail(email)
                 .map(u -> {
                     // 닉네임/프로필 최신화
-                    u.updateProfile(nickname, profileImageUrl);
+                    u.updateFromKakao(email, nickname, profileImageUrl);
                     return u;
                 })
                 .orElseGet(() -> userRepository.save(
                         User.builder()
-                                .provider(AuthProvider.KAKAO)
-                                .providerId(kakaoId)
+                                .kakaoId(kakaoId)
+                                .email(email)
                                 .nickname(nickname != null && !nickname.isBlank() ? nickname : ("카카오사용자_" + kakaoId))
                                 .profileImageUrl(profileImageUrl)
                                 .build()


### PR DESCRIPTION
## 🔥 Related Issues
- close #6 

## 💻 작업 내용
- [x] 이메일 필수 동의 추가
- [x] 이전의 유니크 인덱스 삭제하고 이메일을 고유 식별자로 사용

## ✅ PR Point
- 유니크 인덱스(provider+provider_id) 삭제
- provider, provider_id 칼럼 삭제
- UserRepository에 findByEmail, findByKakaoId 추가
- 카카오 인가 URL 변경

## 😡 Trouble Shooting
DB에 이메일이 안 들어와서 또 헤맸습니다...
1. DB 칼럼을 수정하지 않음
- provider 칼럼들과 유니크 인덱스를 삭제
- email 칼럼 생성
→ 그래도 들어오지 않음
2. 카카오 인가코드 URL에 scope=account_email 추가
- 성공!

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="877" height="341" alt="이메일 동의" src="https://github.com/user-attachments/assets/42720c72-4c53-496a-9072-8a89de17b414" />
<img width="958" height="160" alt="DB_이메일포함" src="https://github.com/user-attachments/assets/a5bf9d3e-1d6b-4ac4-91e4-b0da7e55f230" />
