### PR TITLE
feat: 기록 상세 조회 및 삭제 API 구현

### DIFF
--- a/src/main/java/umc/fitty/converter/RecordConverter.java
+++ b/src/main/java/umc/fitty/converter/RecordConverter.java
@@ -21,4 +21,16 @@ public class RecordConverter {
                 .createdAt(runRecord.getCreatedAt())
                 .build();
     }
+
+    public static RunRecordResponseDTO.RecordDetailDTO toDetailDTO(RunRecord runRecord){
+        return RunRecordResponseDTO.RecordDetailDTO.builder()
+                .recordId(runRecord.getId())
+                .distance(runRecord.getDistance())
+                .durationMin(runRecord.getDurationMin())
+                .diary(runRecord.getDiary())
+                .imageUrl(runRecord.getImageUrl())
+                .createdAt(runRecord.getCreatedAt())
+                .build();
+
+    }
 }

--- a/src/main/java/umc/fitty/service/RunRecordService/RecordQueryService.java
+++ b/src/main/java/umc/fitty/service/RunRecordService/RecordQueryService.java
@@ -1,4 +1,7 @@
 package umc.fitty.service.RunRecordService;
 
+import umc.fitty.domain.RunRecord;
+
 public interface RecordQueryService {
+    RunRecord findRecord(Long recordId);
 }

--- a/src/main/java/umc/fitty/service/RunRecordService/RecordQueryServiceImpl.java
+++ b/src/main/java/umc/fitty/service/RunRecordService/RecordQueryServiceImpl.java
@@ -1,4 +1,24 @@
 package umc.fitty.service.RunRecordService;
 
-public class RecordQueryServiceImpl {
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.fitty.apiPayload.code.ErrorCode;
+import umc.fitty.apiPayload.exception.CustomException;
+import umc.fitty.domain.RunRecord;
+import umc.fitty.repository.RecordRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordQueryServiceImpl implements RecordQueryService {
+
+    private final RecordRepository recordRepository;
+
+
+    @Override
+    public RunRecord findRecord(Long recordId) {
+        return recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
+    }
 }

--- a/src/main/java/umc/fitty/web/controller/RunRecordRestController.java
+++ b/src/main/java/umc/fitty/web/controller/RunRecordRestController.java
@@ -6,6 +6,7 @@ import umc.fitty.apiPayload.ApiResponse;
 import umc.fitty.converter.RecordConverter;
 import umc.fitty.domain.RunRecord;
 import umc.fitty.service.RunRecordService.RecordCommandService;
+import umc.fitty.service.RunRecordService.RecordQueryService;
 import umc.fitty.web.dto.RunRecordDTO.RunRecordRequestDTO;
 import umc.fitty.web.dto.RunRecordDTO.RunRecordResponseDTO;
 
@@ -15,6 +16,7 @@ import umc.fitty.web.dto.RunRecordDTO.RunRecordResponseDTO;
 public class RunRecordRestController {
 
     private final RecordCommandService recordCommandService;
+    private final RecordQueryService recordQueryService;
 
     @PostMapping
     public ApiResponse<RunRecordResponseDTO.RecordResultDTO> createRecord(@RequestBody RunRecordRequestDTO.CreateRecordDTO request) {
@@ -27,5 +29,11 @@ public class RunRecordRestController {
     public ApiResponse<String> deleteRecord(@PathVariable Long recordId) {
         recordCommandService.deleteRecord(recordId);
         return ApiResponse.success("기록이 성공적으로 삭제되었습니다.");
+    }
+
+    @GetMapping("/{recordId}")
+    public ApiResponse<RunRecordResponseDTO.RecordDetailDTO> getRecord(@PathVariable Long recordId) {
+        RunRecord record = recordQueryService.findRecord(recordId);
+        return ApiResponse.success("기록 상세 조회 성공", RecordConverter.toDetailDTO(record));
     }
 }

--- a/src/main/java/umc/fitty/web/dto/RunRecordDTO/RunRecordResponseDTO.java
+++ b/src/main/java/umc/fitty/web/dto/RunRecordDTO/RunRecordResponseDTO.java
@@ -18,4 +18,17 @@ public class RunRecordResponseDTO {
         private Long recordId;
         private LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecordDetailDTO{
+        private long recordId;
+        private Double distance;
+        private Integer durationMin;
+        private String diary;
+        private String imageUrl;
+        private LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #14

## 💻 작업 내용
- [x] 기록 상세 조회 API 구현 (GET /records/{id})
- [x] 조회 로직 분리를 위한 RecordQueryService 추가
- [x] 상세 조회를 위한 RecordDetailDTO 생성

## ✅ PR Point
- 기록 ID로 특정 운동 기록을 조회하는 기능을 추가
- 응답 시에는 생성 DTO와 별개로, 기록의 모든 상세 정보를 담는 RecordDetailDTO를 사용하도록 컨버터에 새로운 메서드를 추가

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="477" height="257" alt="image" src="https://github.com/user-attachments/assets/70ea5208-ab3d-4711-ab9b-a093b935aa50" />

