### PR TITLE
feat: 내 정보 수정

### DIFF
--- a/src/main/java/umc/fitty/domain/User.java
+++ b/src/main/java/umc/fitty/domain/User.java
@@ -8,27 +8,63 @@ import umc.fitty.domain.common.BaseEntity;
 @Table(name = "user", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"email"})
 })
-@Getter @Builder
-@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, length = 50)
     private String kakaoId;
 
-    @Column(length = 100, unique = true)
+    @Column(nullable = false, length = 100, unique = true)
     private String email;
 
-    @Column(nullable = false, length = 50)
+    /** 카카오 원본 프로필 */
+    @Column(length = 50)
+    private String kakaoNickname;
+
+    @Column(length = 255)
+    private String kakaoProfileImageUrl;
+
+    /** 앱 전용 프로필 (사용자 커스텀) */
+    @Column(length = 50)
     private String nickname;
 
     @Column(length = 255)
     private String profileImageUrl;
 
-    public void updateFromKakao(String email, String nickname, String profileImageUrl) {
+    // ====== 동기화 및 업데이트 메서드 ======
+
+    /**
+     * 카카오 로그인 시점에 원본 값만 갱신
+     */
+    public void updateFromKakao(String email, String kakaoNickname, String kakaoProfileImageUrl) {
         if (email != null) this.email = email;
-        if (nickname != null) this.nickname = nickname;
-        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
+        if (kakaoNickname != null) this.kakaoNickname = kakaoNickname;
+        if (kakaoProfileImageUrl != null) this.kakaoProfileImageUrl = kakaoProfileImageUrl;
+    }
+
+    /**
+     * 앱 내 프로필 수정
+     * null이 들어오면 "카카오 값으로 되돌리기"
+     */
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    /** 현재 표시할 닉네임 (앱 값이 우선) */
+    public String getEffectiveNickname() {
+        return (this.nickname != null) ? this.nickname : this.kakaoNickname;
+    }
+
+    /** 현재 표시할 프로필 이미지 (앱 값이 우선) */
+    public String getEffectiveProfileImageUrl() {
+        return (this.profileImageUrl != null) ? this.profileImageUrl : this.kakaoProfileImageUrl;
     }
 }

--- a/src/main/java/umc/fitty/service/UserService.java
+++ b/src/main/java/umc/fitty/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.fitty.domain.*;
 import umc.fitty.repository.UserRepository;
 import umc.fitty.web.dto.UserDTO.UserMeResponseDTO;
+import umc.fitty.web.dto.UserDTO.UserMeUpdateRequestDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -34,12 +35,24 @@ public class UserService {
     public UserMeResponseDTO getMe(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
+        return toResponse(user);
+    }
 
+    @Transactional
+    public UserMeResponseDTO updateMe(Long userId, UserMeUpdateRequestDTO req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
+
+        user.updateProfile(req.getNickname(), req.getProfileImageUrl());
+        return toResponse(user);
+    }
+
+    private UserMeResponseDTO toResponse(User user) {
         return UserMeResponseDTO.builder()
                 .id(user.getId())
                 .email(user.getEmail())
-                .nickname(user.getNickname())
-                .profileImageUrl(user.getProfileImageUrl())
+                .nickname(user.getEffectiveNickname())
+                .profileImageUrl(user.getEffectiveProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/umc/fitty/web/controller/UserController.java
+++ b/src/main/java/umc/fitty/web/controller/UserController.java
@@ -5,13 +5,17 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import umc.fitty.config.security.SecurityUtil;
 import umc.fitty.web.dto.UserDTO.UserMeResponseDTO;
 import umc.fitty.service.UserService;
+import umc.fitty.web.dto.UserDTO.UserMeUpdateRequestDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +37,12 @@ public class UserController {
     public ResponseEntity<UserMeResponseDTO> getMyProfile() {
         Long userId = SecurityUtil.getCurrentUserId();
         return ResponseEntity.ok(userService.getMe(userId));
+    }
+
+    @Operation(summary = "내 정보 수정", security = { @SecurityRequirement(name = "bearerAuth") })
+    @PatchMapping("/me")
+    public ResponseEntity<UserMeResponseDTO> updateMyProfile(@Valid @RequestBody UserMeUpdateRequestDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(userService.updateMe(userId, request));
     }
 }

--- a/src/main/java/umc/fitty/web/dto/UserDTO/UserMeResponseDTO.java
+++ b/src/main/java/umc/fitty/web/dto/UserDTO/UserMeResponseDTO.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class UserMeResponseDTO {
     private Long id;
     private String email;
-    private String nickname;
-    private String profileImageUrl;
+    private String nickname;         // effective 값
+    private String profileImageUrl;  // effective 값
 }

--- a/src/main/java/umc/fitty/web/dto/UserDTO/UserMeUpdateRequestDTO.java
+++ b/src/main/java/umc/fitty/web/dto/UserDTO/UserMeUpdateRequestDTO.java
@@ -1,0 +1,11 @@
+package umc.fitty.web.dto.UserDTO;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserMeUpdateRequestDTO {
+    private String nickname;         // null → 카카오 닉네임으로 되돌림
+    private String profileImageUrl;  // null → 카카오 프로필 이미지로 되돌림
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #18 

## 💻 작업 내용
- [x] 카카오 프로필과 앱 내부 프로필 분리
- [x] 앱 내부 프로필 변경 시 우선 적용, null 시 카카오 프로필 노출
- [x] 유저가 자신의 닉네임, 이메일, 프로필 이미지 조회 가능

## ✅ PR Point
- User 도메인 수정 (앱 내부, 카카오 칼럼 분리)
- User 도메인 내 getEffective 함수를 추가해 우선 적용 구분

## 😡 Trouble Shooting
- 스웨거 테스트 시 null을 입력했을 때 서버 에러가 떴다.
이유는 코드 수정 전 DB에 닉네임, 프로필 이미지를 NOT NULL로 설정해 두었기 때문!
ALTER TABLE user MODIFY COLUMN 해서 NULL 허용으로 수정하니 잘 작동했다.

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="1920" height="1080" alt="Swagger UI" src="https://github.com/user-attachments/assets/a59121c4-d834-4c27-b253-be09ae7460e3" />
<img width="818" height="128" alt="DB" src="https://github.com/user-attachments/assets/af18a505-26d3-4b82-8db6-e636de57c46a" /><br></br>

아래는 내 정보 수정 API에 null 입력 후입니다. <br></br>
<img width="1920" height="1080" alt="Swagger UI_롤백" src="https://github.com/user-attachments/assets/02d75fb8-5485-4597-9e93-627f868573fc" />
<img width="818" height="127" alt="DB_롤백" src="https://github.com/user-attachments/assets/656d48e4-0921-4890-9dcc-8d71a4819035" />
