### PR TITLE
feat: 회원 탈퇴

### DIFF
--- a/src/main/java/umc/fitty/config/security/CustomUserDetailService.java
+++ b/src/main/java/umc/fitty/config/security/CustomUserDetailService.java
@@ -1,6 +1,7 @@
 package umc.fitty.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -27,6 +28,10 @@ public class CustomUserDetailService implements UserDetailsService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
+
+        if (user.isDeleted()) {
+            throw new DisabledException("탈퇴한 사용자입니다.");
+        }
 
         return UserPrincipal.from(user);
     }

--- a/src/main/java/umc/fitty/domain/User.java
+++ b/src/main/java/umc/fitty/domain/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.fitty.domain.common.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "user", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"email"})
@@ -37,6 +39,29 @@ public class User extends BaseEntity {
 
     @Column(length = 255)
     private String profileImageUrl;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    private LocalDateTime deletedAt;
+
+    @Column(length = 1000)
+    private String withdrawReason;
+
+    @Column(length = 2000)
+    private String withdrawFeedback;
+
+    public boolean isActive() {
+        return !this.isDeleted;
+    }
+
+    public void withdraw(String reason, String feedback) {
+        if (this.isDeleted) return;
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.withdrawReason = reason;
+        this.withdrawFeedback = feedback;
+    }
 
     // ====== 동기화 및 업데이트 메서드 ======
 

--- a/src/main/java/umc/fitty/repository/UserRepository.java
+++ b/src/main/java/umc/fitty/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByKakaoId(String kakaoId);
+    Optional<User> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/umc/fitty/service/UserService.java
+++ b/src/main/java/umc/fitty/service/UserService.java
@@ -7,6 +7,7 @@ import umc.fitty.domain.*;
 import umc.fitty.repository.UserRepository;
 import umc.fitty.web.dto.UserDTO.UserMeResponseDTO;
 import umc.fitty.web.dto.UserDTO.UserMeUpdateRequestDTO;
+import umc.fitty.web.dto.UserDTO.UserWithdrawRequestDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -54,5 +55,21 @@ public class UserService {
                 .nickname(user.getEffectiveNickname())
                 .profileImageUrl(user.getEffectiveProfileImageUrl())
                 .build();
+    }
+
+    @Transactional
+    public void withdrawUser(Long userId, UserWithdrawRequestDTO req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (user.isDeleted()) {
+            // 멱등 처리: 이미 탈퇴 상태면 그냥 통과
+            return;
+        }
+
+        user.withdraw(
+                req != null ? req.getReason() : null,
+                req != null ? req.getFeedback() : null
+        );
     }
 }

--- a/src/main/java/umc/fitty/web/controller/UserController.java
+++ b/src/main/java/umc/fitty/web/controller/UserController.java
@@ -16,6 +16,7 @@ import umc.fitty.config.security.SecurityUtil;
 import umc.fitty.web.dto.UserDTO.UserMeResponseDTO;
 import umc.fitty.service.UserService;
 import umc.fitty.web.dto.UserDTO.UserMeUpdateRequestDTO;
+import umc.fitty.web.dto.UserDTO.UserWithdrawRequestDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,5 +45,19 @@ public class UserController {
     public ResponseEntity<UserMeResponseDTO> updateMyProfile(@Valid @RequestBody UserMeUpdateRequestDTO request) {
         Long userId = SecurityUtil.getCurrentUserId();
         return ResponseEntity.ok(userService.updateMe(userId, request));
+    }
+
+    @PatchMapping("/me/withdraw")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자를 소프트 삭제합니다.",
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ResponseEntity<Void> withdrawMe(
+            @RequestBody(required = false) @Valid UserWithdrawRequestDTO request
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        userService.withdrawUser(userId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/umc/fitty/web/dto/UserDTO/UserWithdrawRequestDTO.java
+++ b/src/main/java/umc/fitty/web/dto/UserDTO/UserWithdrawRequestDTO.java
@@ -1,0 +1,15 @@
+package umc.fitty.web.dto.UserDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserWithdrawRequestDTO {
+    @Schema(description = "탈퇴 사유", example = "서비스 이용이 불편했어요")
+    private String reason;
+
+    @Schema(description = "추가 피드백", example = "기록 화면 동선이 헷갈립니다")
+    private String feedback;
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #20 

## 💻 작업 내용
- [x] 회원 탈퇴 시 is_deleted 활성화
- [x] 탈퇴 사유, 피드백을 요청해 DB에 저장

## ✅ PR Point
- User 엔티티에 탈퇴 칼럼 추가
- UserService에서 멱등성을 위해 is_deleted = true 이면 return
- CustomUserDetailService에서 탈퇴 계정 로그인 차단

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="1920" height="1080" alt="Swagger UI" src="https://github.com/user-attachments/assets/e930d909-f729-4f2a-88f1-ee2a5e3aff3f" />
<img width="819" height="128" alt="DB" src="https://github.com/user-attachments/assets/a354d3bf-e37b-40a2-b34e-a5e2ef0f3010" />
