### PR TITLE
feat: 캐릭터 생성 API 구현

### DIFF
--- a/src/main/java/umc/fitty/apiPayload/code/ErrorCode.java
+++ b/src/main/java/umc/fitty/apiPayload/code/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 
     GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "목표 정보를 찾을 수 없습니다."),
 
+    CHARACTER_ALREADY_EXISTS(HttpStatus.CONFLICT, "캐릭터가 이미 존재 합니다."),
+
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "기록 정보를 찾을 수 없습니다."),
 
     // User Error

--- a/src/main/java/umc/fitty/converter/CharacterConverter.java
+++ b/src/main/java/umc/fitty/converter/CharacterConverter.java
@@ -1,0 +1,26 @@
+package umc.fitty.converter;
+
+import umc.fitty.domain.Character;
+import umc.fitty.domain.enums.CharacterType;
+import umc.fitty.web.dto.CharacterDTO.CharacterRequestDTO;
+import umc.fitty.web.dto.CharacterDTO.CharacterResponseDTO;
+
+public class CharacterConverter {
+
+    public static Character toCharacter(CharacterRequestDTO.CreateCharacterDTO request){
+
+        CharacterType characterType = CharacterType.valueOf(request.getType().toUpperCase());
+
+        return Character.builder()
+                .name(request.getName())
+                .type(characterType)
+                .build();
+    }
+
+    public static CharacterResponseDTO.CreateCharacterResultDTO toCharacterResultDTO(Character character){
+        return CharacterResponseDTO.CreateCharacterResultDTO.builder()
+                .characterId(character.getId())
+                .createdAt(character.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/umc/fitty/domain/Character.java
+++ b/src/main/java/umc/fitty/domain/Character.java
@@ -1,4 +1,36 @@
 package umc.fitty.domain;
 
-public class Character {
+import jakarta.persistence.*;
+import lombok.*;
+import umc.fitty.domain.common.BaseEntity;
+import umc.fitty.domain.enums.CharacterType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Character extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String name;
+
+    @Builder.Default
+    private int level = 1;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CharacterType type;
+
+    private void setUser(User user) {
+        this.user = user;
+    }
+
 }

--- a/src/main/java/umc/fitty/domain/Character.java
+++ b/src/main/java/umc/fitty/domain/Character.java
@@ -6,6 +6,7 @@ import umc.fitty.domain.common.BaseEntity;
 import umc.fitty.domain.enums.CharacterType;
 
 @Entity
+@Table(name = "characters")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,7 +30,7 @@ public class Character extends BaseEntity {
     @Column(nullable = false, length = 20)
     private CharacterType type;
 
-    private void setUser(User user) {
+    public void setUser(User user) {
         this.user = user;
     }
 

--- a/src/main/java/umc/fitty/domain/enums/CharacterType.java
+++ b/src/main/java/umc/fitty/domain/enums/CharacterType.java
@@ -1,0 +1,5 @@
+package umc.fitty.domain.enums;
+
+public enum CharacterType {
+    CAT, DOG
+}

--- a/src/main/java/umc/fitty/repository/CharacterRepository.java
+++ b/src/main/java/umc/fitty/repository/CharacterRepository.java
@@ -1,0 +1,9 @@
+package umc.fitty.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.fitty.domain.Character;
+import umc.fitty.domain.User;
+
+public interface CharacterRepository extends JpaRepository<Character, Long> {
+    boolean existsByUser(User user);
+}

--- a/src/main/java/umc/fitty/service/CharacterService/CharacterCommandImpl.java
+++ b/src/main/java/umc/fitty/service/CharacterService/CharacterCommandImpl.java
@@ -1,0 +1,47 @@
+package umc.fitty.service.CharacterService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.fitty.apiPayload.code.ErrorCode;
+import umc.fitty.apiPayload.exception.CustomException;
+import umc.fitty.converter.CharacterConverter;
+import umc.fitty.domain.Character;
+import umc.fitty.domain.User;
+import umc.fitty.repository.CharacterRepository;
+import umc.fitty.repository.UserRepository;
+import umc.fitty.web.dto.CharacterDTO.CharacterRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CharacterCommandImpl implements CharacterCommandService{
+
+    private final CharacterRepository characterRepository;
+    private final UserRepository userRepository;
+
+
+    @Override
+    public Character createCharacter(CharacterRequestDTO.CreateCharacterDTO request) {
+        User user = findCurrentUser();
+
+        if (characterRepository.existsByUser(user)){
+            throw new CustomException(ErrorCode.CHARACTER_ALREADY_EXISTS);
+        }
+
+        Character newCharacter = CharacterConverter.toCharacter(request);
+
+        newCharacter.setUser(user);
+
+        return characterRepository.save(newCharacter);
+    }
+
+    private User findCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+        return userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/fitty/service/CharacterService/CharacterCommandService.java
+++ b/src/main/java/umc/fitty/service/CharacterService/CharacterCommandService.java
@@ -1,0 +1,9 @@
+package umc.fitty.service.CharacterService;
+
+import umc.fitty.domain.Character;
+import umc.fitty.web.dto.CharacterDTO.CharacterRequestDTO;
+
+public interface CharacterCommandService {
+
+    Character createCharacter(CharacterRequestDTO.CreateCharacterDTO request);
+}

--- a/src/main/java/umc/fitty/web/controller/CharacterRestController.java
+++ b/src/main/java/umc/fitty/web/controller/CharacterRestController.java
@@ -1,0 +1,28 @@
+package umc.fitty.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.fitty.apiPayload.ApiResponse;
+import umc.fitty.converter.CharacterConverter;
+import umc.fitty.domain.Character;
+import umc.fitty.service.CharacterService.CharacterCommandService;
+import umc.fitty.web.dto.CharacterDTO.CharacterRequestDTO;
+import umc.fitty.web.dto.CharacterDTO.CharacterResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/me/character")
+public class CharacterRestController {
+
+    private final CharacterCommandService characterCommandService;
+
+    @PostMapping
+    public ApiResponse<CharacterResponseDTO.CreateCharacterResultDTO> createCharacter(@RequestBody CharacterRequestDTO.CreateCharacterDTO request) {
+        Character character = characterCommandService.createCharacter(request);
+        return ApiResponse.success("캐릭터가 성공적으로 생성되었습니다.", CharacterConverter.toCharacterResultDTO(character));
+    }
+}

--- a/src/main/java/umc/fitty/web/dto/CharacterDTO/CharacterRequestDTO.java
+++ b/src/main/java/umc/fitty/web/dto/CharacterDTO/CharacterRequestDTO.java
@@ -1,0 +1,12 @@
+package umc.fitty.web.dto.CharacterDTO;
+
+import lombok.Getter;
+
+public class CharacterRequestDTO {
+
+    @Getter
+    public static class CreateCharacterDTO {
+        private String name;
+        private String type;
+    }
+}

--- a/src/main/java/umc/fitty/web/dto/CharacterDTO/CharacterResponseDTO.java
+++ b/src/main/java/umc/fitty/web/dto/CharacterDTO/CharacterResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.fitty.web.dto.CharacterDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class CharacterResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateCharacterResultDTO{
+
+            private Long characterId;
+            private LocalDateTime createdAt;
+
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #17

## 💻 작업 내용
- [x] 캐릭터 생성 API 구현 (
- [x] Character 엔티티, DTO, Converter, Repository, Service, Controller 구현

## ✅ PR Point
- 사용자가 자신의 캐릭터 이름과 타입을 정해 새로운 캐릭터를 생성하는 기능을 구현
- User와 Character는 1:1 관계이므로, 이미 캐릭터가 있는 유저가 또 생성하려고 하면 CHARACTER_ALREADY_EXISTS 에러가 발생하도록 처리
- DTO에서는 type을 String으로 받고, 서버 내부에서는 enum으로 변환해서 사용하도록 구현


## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="640" height="196" alt="image" src="https://github.com/user-attachments/assets/046f2c2d-f779-4234-bee5-4d10eb3b1986" />
<img width="1420" height="148" alt="image" src="https://github.com/user-attachments/assets/57c7fda2-47b4-4cbb-8858-188a9ee6c904" />

