### PR TITLE
feat: 피드 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/umc/fitty/converter/CommentConverter.java
+++ b/src/main/java/umc/fitty/converter/CommentConverter.java
@@ -1,0 +1,21 @@
+package umc.fitty.converter;
+
+import umc.fitty.domain.Comment;
+import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
+import umc.fitty.web.dto.CommentDTO.CommentResponseDTO;
+
+public class CommentConverter {
+
+    public static Comment toComment(CommentRequestDTO.CreateCommentDTO request) {
+        return Comment.builder()
+                .content(request.getContent())
+                .build();
+    }
+
+    public static CommentResponseDTO.CreateCommentResultDTO toCreateCommentResultDTO(Comment comment) {
+        return CommentResponseDTO.CreateCommentResultDTO.builder()
+                .commentId(comment.getId())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/umc/fitty/domain/Comment.java
+++ b/src/main/java/umc/fitty/domain/Comment.java
@@ -1,4 +1,34 @@
 package umc.fitty.domain;
 
-public class Comment {
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.fitty.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id")
+    private RunRecord record;
+
+    public void setUserAndRunRecord(User user, RunRecord record) {
+        this.user = user;
+        this.record = record;
+    }
 }

--- a/src/main/java/umc/fitty/repository/CommentRepository.java
+++ b/src/main/java/umc/fitty/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package umc.fitty.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.fitty.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+}

--- a/src/main/java/umc/fitty/service/CommentService/CommentCommandService.java
+++ b/src/main/java/umc/fitty/service/CommentService/CommentCommandService.java
@@ -1,0 +1,9 @@
+package umc.fitty.service.CommentService;
+
+import umc.fitty.domain.Comment;
+import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
+
+public interface CommentCommandService {
+
+    Comment createComment(Long recordId, CommentRequestDTO.CreateCommentDTO request);
+}

--- a/src/main/java/umc/fitty/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/umc/fitty/service/CommentService/CommentCommandServiceImpl.java
@@ -1,0 +1,48 @@
+package umc.fitty.service.CommentService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.fitty.apiPayload.code.ErrorCode;
+import umc.fitty.apiPayload.exception.CustomException;
+import umc.fitty.converter.CommentConverter;
+import umc.fitty.domain.Comment;
+import umc.fitty.domain.RunRecord;
+import umc.fitty.domain.User;
+import umc.fitty.repository.CommentRepository;
+import umc.fitty.repository.RecordRepository;
+import umc.fitty.repository.UserRepository;
+import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCommandServiceImpl implements CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final RecordRepository recordRepository;
+
+    @Override
+    public Comment createComment(Long recordId, CommentRequestDTO.CreateCommentDTO request) {
+        User user = findCurrentUser();
+
+        RunRecord record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
+
+        Comment newComment = CommentConverter.toComment(request);
+
+        newComment.setUserAndRunRecord(user, record);
+        return commentRepository.save(newComment);
+    }
+
+    private User findCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+        return userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/umc/fitty/web/controller/CommentRestController.java
+++ b/src/main/java/umc/fitty/web/controller/CommentRestController.java
@@ -1,0 +1,29 @@
+package umc.fitty.web.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.fitty.apiPayload.ApiResponse;
+import umc.fitty.converter.CommentConverter;
+import umc.fitty.domain.Comment;
+import umc.fitty.service.CommentService.CommentCommandService;
+import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
+import umc.fitty.web.dto.CommentDTO.CommentResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feed")
+public class CommentRestController {
+
+    private final CommentCommandService commentCommandService;
+
+    @PostMapping("/{recordId}/comments")
+    public ApiResponse<CommentResponseDTO.CreateCommentResultDTO> createComment(
+            @PathVariable(name = "recordId") Long recordId, @Valid @RequestBody CommentRequestDTO.CreateCommentDTO request) {
+
+
+        Comment newComment = commentCommandService.createComment(recordId, request);
+
+        return ApiResponse.success("댓글이 성공적으로 작성되었습니다.", CommentConverter.toCreateCommentResultDTO(newComment));
+    }
+}

--- a/src/main/java/umc/fitty/web/dto/CommentDTO/CommentRequestDTO.java
+++ b/src/main/java/umc/fitty/web/dto/CommentDTO/CommentRequestDTO.java
@@ -1,0 +1,14 @@
+package umc.fitty.web.dto.CommentDTO;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class CommentRequestDTO {
+
+    @Getter
+    public static class CreateCommentDTO {
+
+        @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
+        private String content;
+    }
+}

--- a/src/main/java/umc/fitty/web/dto/CommentDTO/CommentResponseDTO.java
+++ b/src/main/java/umc/fitty/web/dto/CommentDTO/CommentResponseDTO.java
@@ -1,0 +1,21 @@
+package umc.fitty.web.dto.CommentDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class CommentResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateCommentResultDTO {
+        private Long commentId;
+        private LocalDateTime createdAt;
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #30 

## 💻 작업 내용
- [x] 사용자가 특정 운동 기록(피드 게시글)에 댓글을 작성하는 API를 구현

## ✅ PR Point
- Comment 엔티티 및 CommentRepository를 생성하고, User 및 RunRecord와 N:1 연관관계를 설정
- POST /feed/{recordId}/comments 요청을 처리하는 CommentRestController를 구현했습니다.
- 요청/응답 데이터를 처리하기 위한 CommentDTO와 엔티티-DTO 변환을 위한 CommentConverter를 추가했습니다.
- CommentCommandService에 댓글 생성 비즈니스 로직을 구현하여 각 계층의 역할을 명확히 분리했습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="882" height="252" alt="image" src="https://github.com/user-attachments/assets/46d2ddd6-1882-4fe5-81ab-122f4dc819ef" />
<img width="1403" height="212" alt="image" src="https://github.com/user-attachments/assets/0ab86e2a-973d-4a4d-9fdc-dfc2eed8983a" />

