### PR TITLE
feat: 피드 댓글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/umc/fitty/converter/CommentConverter.java
+++ b/src/main/java/umc/fitty/converter/CommentConverter.java
@@ -1,8 +1,12 @@
 package umc.fitty.converter;
 
+import org.springframework.data.domain.Page;
 import umc.fitty.domain.Comment;
 import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
 import umc.fitty.web.dto.CommentDTO.CommentResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommentConverter {
 
@@ -15,6 +19,34 @@ public class CommentConverter {
     public static CommentResponseDTO.CreateCommentResultDTO toCreateCommentResultDTO(Comment comment) {
         return CommentResponseDTO.CreateCommentResultDTO.builder()
                 .commentId(comment.getId())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    public static CommentResponseDTO.CommentListDTO toCommentListDTO(Page<Comment> commentPage) {
+
+        List<Comment> commentEntityList = commentPage.getContent();
+
+        List<CommentResponseDTO.CommentPreviewDTO> commentPreviewDTOList = commentEntityList.stream()
+                .map(CommentConverter::toCommentPreviewDTO)
+                .collect(Collectors.toList());
+
+        return CommentResponseDTO.CommentListDTO.builder()
+                .commentList(commentPreviewDTOList)
+                .listSize(commentPreviewDTOList.size())
+                .totalPage(commentPage.getTotalPages())
+                .totalElements(commentPage.getTotalElements())
+                .isFirst(commentPage.isFirst())
+                .isLast(commentPage.isLast())
+                .build();
+    }
+
+    public static CommentResponseDTO.CommentPreviewDTO toCommentPreviewDTO(Comment comment) {
+        return CommentResponseDTO.CommentPreviewDTO.builder()
+                .commentId(comment.getId())
+                .userNickname(comment.getUser().getEffectiveNickname())
+                .userProfileUrl(comment.getUser().getEffectiveProfileImageUrl())
+                .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/umc/fitty/repository/CommentRepository.java
+++ b/src/main/java/umc/fitty/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package umc.fitty.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.fitty.domain.Comment;
+import umc.fitty.domain.RunRecord;
 
 public interface CommentRepository extends JpaRepository<Comment,Long> {
+
+    Page<Comment> findByRecord(RunRecord runRecord, Pageable pageable);
+
 }

--- a/src/main/java/umc/fitty/service/CommentService/CommentQueryService.java
+++ b/src/main/java/umc/fitty/service/CommentService/CommentQueryService.java
@@ -1,0 +1,9 @@
+package umc.fitty.service.CommentService;
+
+import org.springframework.data.domain.Page;
+import umc.fitty.domain.Comment;
+
+public interface CommentQueryService{
+
+    Page<Comment> getCommentList(Long recordId, int page);
+}

--- a/src/main/java/umc/fitty/service/CommentService/CommentQueryServiceImpl.java
+++ b/src/main/java/umc/fitty/service/CommentService/CommentQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package umc.fitty.service.CommentService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.fitty.apiPayload.code.ErrorCode;
+import umc.fitty.apiPayload.exception.CustomException;
+import umc.fitty.domain.Comment;
+import umc.fitty.domain.RunRecord;
+import umc.fitty.repository.CommentRepository;
+import umc.fitty.repository.RecordRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryServiceImpl implements CommentQueryService{
+
+    private final RecordRepository recordRepository;
+    private final CommentRepository commentRepository;
+
+
+    @Override
+    public Page<Comment> getCommentList(Long recordId, int page) {
+        RunRecord runRecord = recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return commentRepository.findByRecord(runRecord, pageable);
+    }
+}

--- a/src/main/java/umc/fitty/web/controller/CommentRestController.java
+++ b/src/main/java/umc/fitty/web/controller/CommentRestController.java
@@ -2,11 +2,13 @@ package umc.fitty.web.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import umc.fitty.apiPayload.ApiResponse;
 import umc.fitty.converter.CommentConverter;
 import umc.fitty.domain.Comment;
 import umc.fitty.service.CommentService.CommentCommandService;
+import umc.fitty.service.CommentService.CommentQueryService;
 import umc.fitty.web.dto.CommentDTO.CommentRequestDTO;
 import umc.fitty.web.dto.CommentDTO.CommentResponseDTO;
 
@@ -16,6 +18,7 @@ import umc.fitty.web.dto.CommentDTO.CommentResponseDTO;
 public class CommentRestController {
 
     private final CommentCommandService commentCommandService;
+    private final CommentQueryService commentQueryService;
 
     @PostMapping("/{recordId}/comments")
     public ApiResponse<CommentResponseDTO.CreateCommentResultDTO> createComment(
@@ -25,5 +28,15 @@ public class CommentRestController {
         Comment newComment = commentCommandService.createComment(recordId, request);
 
         return ApiResponse.success("댓글이 성공적으로 작성되었습니다.", CommentConverter.toCreateCommentResultDTO(newComment));
+    }
+
+    @GetMapping("/{recordId}/comments")
+    public ApiResponse<CommentResponseDTO.CommentListDTO> getCommentList(
+            @PathVariable(name = "recordId") Long recordId,
+            @RequestParam(name = "page") Integer page){
+
+        Page<Comment> commentPage = commentQueryService.getCommentList(recordId, page);
+
+        return ApiResponse.success("댓글 목록 조회가 성공했습니다.", CommentConverter.toCommentListDTO(commentPage));
     }
 }

--- a/src/main/java/umc/fitty/web/dto/CommentDTO/CommentResponseDTO.java
+++ b/src/main/java/umc/fitty/web/dto/CommentDTO/CommentResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class CommentResponseDTO {
 
@@ -15,6 +16,31 @@ public class CommentResponseDTO {
     @AllArgsConstructor
     public static class CreateCommentResultDTO {
         private Long commentId;
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentListDTO {
+        private List<CommentPreviewDTO> commentList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentPreviewDTO {
+        private Long commentId;
+        private String userNickname;
+        private String userProfileUrl;
+        private String content;
         private LocalDateTime createdAt;
     }
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #35

## 💻 작업 내용
- [x] GET /feed/{recordId}/comments API 엔드포인트 구현
- [x] CommentQueryService에 특정 게시글의 댓글 목록 조회 로직 추가
- [x]  Pageable을 이용한 페이지네이션 및 최신순 정렬 적용
- [x] 응답 데이터용 CommentListDTO, CommentPreviewDTO 생성

## ✅ PR Point
- PageRequest.of()를 사용한 페이지네이션 및 정렬 처리 방식
- 게시글이 없을 때 RECORD_NOT_FOUND 예외 처리 확인


## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="1158" height="902" alt="image" src="https://github.com/user-attachments/assets/72836f7c-a0a6-4dc1-9117-9a7c92afd3d6" />

